### PR TITLE
Fix bug with getTeamList

### DIFF
--- a/thebluealliance.js
+++ b/thebluealliance.js
@@ -112,7 +112,7 @@ class initTBA {
   // 'Team List Request' on TBA API docs
   // gets all the teams on one page of the team list at TBA
   getTeamList (pageNum, callback) {
-    let url = `/teams/` + pageNum;
+    let url = `/teams/${pageNum}`;
 
     this.tbaRequest(url, callback);
   };

--- a/thebluealliance.js
+++ b/thebluealliance.js
@@ -112,7 +112,7 @@ class initTBA {
   // 'Team List Request' on TBA API docs
   // gets all the teams on one page of the team list at TBA
   getTeamList (pageNum, callback) {
-    let url = this.ROOT_URL + 'teams/' + pageNum;
+    let url = `/teams/` + pageNum;
 
     this.tbaRequest(url, callback);
   };


### PR DESCRIPTION
The getTeamList function would append the ROOT_URL to the URL provided, making the URL unusable.